### PR TITLE
Setting AR path usually causes issues with finding the executable

### DIFF
--- a/cpresets/windows.json
+++ b/cpresets/windows.json
@@ -12,7 +12,6 @@
       "inherits": "windows",
       "cacheVariables":
       {
-        "CMAKE_AR": "lib.exe",
         "CMAKE_CXX_COMPILER": "cl.exe",
         "CMAKE_C_COMPILER": "cl.exe",
         "CMAKE_LINKER": "link.exe"


### PR DESCRIPTION
CMake sets it to be a path relative to the current build directory